### PR TITLE
[ISSUE-5] implement `BASH` shell completion for pokego using complegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Download the latest release. Unzip the executable, and move it to `/usr/bin`
 You can also clone the repository and compile manually by doing:
 ```sh
 git clone https://github.com/rubiin/pokego.git
-cd pokeget
+cd pokego
 just build
 
 ```

--- a/usage/pokego.usage
+++ b/usage/pokego.usage
@@ -1,0 +1,13 @@
+pokego [<OPTION>];
+
+<OPTION> ::= (--help)
+           | (-form)
+           | (-list)
+           | (-name )
+           | (-no-title)
+           | (-random)
+           | (-shiny)
+           | (-version)
+           ;
+
+

--- a/usage/pokego.usage
+++ b/usage/pokego.usage
@@ -1,6 +1,6 @@
 pokego [<OPTION>];
 
-<OPTION> ::= (--help)
+<OPTION> ::= (-h | --help)
            | (-form)
            | (-list)
            | (-name )


### PR DESCRIPTION
### Description / Changes made in this PR
1. added `usage/pokego.usage` which is used for shell completion of `complgen`
2. minor: in `README.md`, fix `pokeget` -> `pokego`


### Linked Issues
Resolves #5 

### Additional context
1. to run:

```
cd pokego
complgen aot --bash-script ./usage/my_pokego.bash ./usage/pokego.usage
source ./usage/my_pokego.bash  # must source it to take effect
# now you can test the commands
```

Output when attempting to complete looks like this:
```
$ pokego -
--help      -form       -h          -list       -name       -no-title   -random     -shiny      -version
```

